### PR TITLE
Rewrite of the utility names

### DIFF
--- a/src/collective/taxonomy/behavior.py
+++ b/src/collective/taxonomy/behavior.py
@@ -33,14 +33,13 @@ logger = logging.getLogger("collective.taxonomy")
 class TaxonomyBehavior(Persistent):
     implements(IBehavior)
 
-    def __init__(self, name, title, description, field_name,
-                 field_title, field_description, is_required=False,
+    def __init__(self, name, title, description, field_title,
+                 field_description, is_required=False,
                  multi_select=False, write_permission=''):
         self.name = name
         self.title = _(title)
         self.description = _(description)
         self.factory = None
-        self.field_name = field_name
         self.field_title = field_title
         self.field_description = field_description
         self.is_required = is_required
@@ -110,6 +109,14 @@ class TaxonomyBehavior(Persistent):
         return str(self.name.split('.')[-1])
 
     @property
+    def field_name(self):
+        return 'taxonomy_' + self.short_name
+
+    @property
+    def vocabulary_name(self):
+        return 'collective.taxonomy.' + self.short_name
+
+    @property
     def interface(self):
         if hasattr(generated, self.short_name):
             return getattr(generated, self.short_name)
@@ -118,16 +125,14 @@ class TaxonomyBehavior(Persistent):
             title=_(unicode(self.field_title)),
             description=_(unicode(self.field_description)),
             required=self.is_required,
-            vocabulary='collective.taxonomy.' +
-            self.short_name)
+            vocabulary=self.vocabulary_name)
 
         multi_select_field = schema.List(
             title=_(unicode(self.field_title)),
             description=_(unicode(self.field_description)),
             value_type=schema.Choice(
                 required=self.is_required,
-                vocabulary='collective.taxonomy.' +
-                self.short_name))
+                vocabulary=self.vocabulary_name))
 
         schemaclass = SchemaClass(
             self.short_name, (form.Schema, ),

--- a/src/collective/taxonomy/exportimport.py
+++ b/src/collective/taxonomy/exportimport.py
@@ -49,6 +49,7 @@ class TaxonomyImportExportAdapter(object):
             site = self.context
 
         normalizer = getUtility(IIDNormalizer)
+
         tree = ElementTree.fromstring(document)
         default_language = tree.attrib['language']
 
@@ -57,7 +58,8 @@ class TaxonomyImportExportAdapter(object):
         title = tree.find('./{%s}vocabName/{%s}langstring'
                           % (self.IMSVDEX_NS, self.IMSVDEX_NS))
 
-        utility_name = 'collective.taxonomy.' + normalizer.normalize(name.text)
+        normalized_name = normalizer.normalize(name.text).replace('-', '')
+        utility_name = 'collective.taxonomy.' + normalized_name
         taxonomy = queryUtility(ITaxonomy, name=utility_name)
 
         if taxonomy is None:

--- a/src/collective/taxonomy/utility.py
+++ b/src/collective/taxonomy/utility.py
@@ -58,6 +58,9 @@ class Taxonomy(SimpleItem):
     def getGeneratedName(self):
         return 'collective.taxonomy.generated.' + self.getShortName()
 
+    def getVocabularyName(self):
+        return 'collective.taxonomy.' + self.getShortName()
+
     def getCurrentLanguage(self, request):
         try:
             portal_state = getMultiAdapter(

--- a/src/collective/taxonomy/vocabulary.py
+++ b/src/collective/taxonomy/vocabulary.py
@@ -8,9 +8,9 @@ from zope.schema.interfaces import IVocabulary, IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm, SimpleVocabulary
 from zope.security.interfaces import IPermission
 from zope.component.hooks import getSite
-from plone.behavior.interfaces import IBehavior
 
 _pmf = MessageFactory('plone')
+
 
 class TaxonomyVocabulary(object):
     # Vocabulary for generating a list of existing taxonomies
@@ -19,21 +19,12 @@ class TaxonomyVocabulary(object):
 
     def __call__(self, adapter):
         results = []
-        context = adapter.context
         sm = getSite().getSiteManager()
         utilities = sm.getUtilitiesFor(ITaxonomy)
 
         for (utility_name, utility) in utilities:
-            short_name = utility_name.split('.')[-1]
-            behavior_name = 'collective.taxonomy.generated.' + short_name
-            behavior = sm.queryUtility(IBehavior,
-                                       name=behavior_name)
-
             utility_name = utility.name
             utility_title = utility.title
-
-            if behavior:
-                field_name = behavior.field_name
 
             results.append(SimpleTerm(value=utility_name,
                                       title=utility_title)
@@ -81,6 +72,7 @@ class Vocabulary(object):
 
         return results
 
+
 class PermissionsVocabulary(object):
     implements(IVocabularyFactory)
 
@@ -94,4 +86,3 @@ class PermissionsVocabulary(object):
 
         result.sort(key=lambda permission: permission.title)
         return SimpleVocabulary(result)
-


### PR DESCRIPTION
The name of the behaviour and various utilities (translation domain, taxonomy, vocabulary factory) are based only on the `vocabIdentifier` token from the VDEX-file. Further, fields are prefixed by `taxonomy_<name>`. 
