### PR TITLE
Taxonomy "inverted_data" ram cache key calc method bugfix

### DIFF
--- a/src/collective/taxonomy/utility.py
+++ b/src/collective/taxonomy/utility.py
@@ -44,7 +44,7 @@ class Taxonomy(SimpleItem):
         return Vocabulary(self.name, data, inverted_data)
 
     @property
-    @ram.cache(lambda method, self: self.data._p_mtime)
+    @ram.cache(lambda method, self: (self.name, self.data._p_mtime))
     def inverted_data(self):
         inv_data = {}
         for (language, elements) in self.data.items():


### PR DESCRIPTION
I found when import several taxonomy at the same time, then used them in a dexterity content type add/edit form, only the first taxnomy will show correctly, the others not get the right title(display). After debug, I found the issue is caused by "inverted_data" ram cache key calc method.

Current code (in utility.py):

``` python
class Taxonomy(SimpleItem):
    ...
    @property
    @ram.cache(lambda method, self: self.data._p_mtime)  # bug line
    def inverted_data(self):
        inv_data = {}
        for (language, elements) in self.data.items():
            inv_data[language] = {}
            for (path, identifier) in elements.items():
                inv_data[language][identifier] = path
        return inv_data
```

Change the cache key method to the following fix the bug:

@ram.cache(lambda method, self: (self.name, self.data._p_mtime))
