### PR TITLE
Use context language to find index

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changes
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use context language if to find index.
+  [bsuttor]
 
 
 1.3.0 (2016-07-07)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes
 1.3.1 (unreleased)
 ------------------
 
-- Use context language if to find index.
+- Use context language to find index.
   [bsuttor]
 
 

--- a/src/collective/taxonomy/indexer.py
+++ b/src/collective/taxonomy/indexer.py
@@ -49,8 +49,9 @@ class TaxonomyIndexerWrapper(object):
                 if identifier in stored_element:
                     found.append((identifier, language, path,))
 
+        lang = getattr(self.context, 'language', language)
         result = []
-        for (key, value) in utility.inverted_data[language].items():
+        for (key, value) in utility.inverted_data[lang].items():
             for (found_identifier, found_language, found_path) in found:
                 in_path = False
                 for s in value.split('/'):
@@ -62,7 +63,6 @@ class TaxonomyIndexerWrapper(object):
                 if in_path:
                     if key not in result:
                         result.append(key)
-
         return result
 
 

--- a/src/collective/taxonomy/profile/taxonomies/nihms.xml
+++ b/src/collective/taxonomy/profile/taxonomies/nihms.xml
@@ -32,5 +32,11 @@
         <langstring language="en">Chronology</langstring>
       </caption>
     </term>
+    <term>
+      <termIdentifier>5</termIdentifier>
+      <caption>
+        <langstring language="en">Sport</langstring>
+      </caption>
+    </term>
   </term>
 </vdex>


### PR DESCRIPTION
Before, language was get by last value of utility.data.items(),
But it seems kind of good fortune when taxonomy exists in different language than context language.