### PR TITLE
Fix empty context.REQUEST.get('form.widgets.taxonomy')

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes
 1.3.1 (unreleased)
 ------------------
 
+- Fix empty context.REQUEST.get('form.widgets.taxonomy'). It add it into POST form.
+  [bsuttor]
+
 - Plone 5 compatibility
   [tomgross]
 

--- a/src/collective/taxonomy/interfaces.py
+++ b/src/collective/taxonomy/interfaces.py
@@ -52,7 +52,10 @@ class ITaxonomySettings(Interface):
 
 
 def taxonomyDefaultValue():
-    return api.portal.get().REQUEST.get('form.widgets.taxonomy')
+    taxonomy = api.portal.get().REQUEST.get('form.widgets.taxonomy')
+    if not taxonomy:
+        return u''
+    return taxonomy
 
 
 class ITaxonomyForm(Interface):

--- a/src/collective/taxonomy/interfaces.py
+++ b/src/collective/taxonomy/interfaces.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from plone import api
 from plone.namedfile.field import NamedBlobFile
 
 from zope.interface import Interface
@@ -50,12 +51,17 @@ class ITaxonomySettings(Interface):
     )
 
 
+def taxonomyDefaultValue():
+    return api.portal.get().REQUEST.get('form.widgets.taxonomy')
+
+
 class ITaxonomyForm(Interface):
 
     taxonomy = schema.TextLine(
         title=_(u"Taxonomy"),
         description=_("The taxonomy identifier"),
-        required=True
+        required=True,
+        defaultFactory=taxonomyDefaultValue,
     )
 
     field_title = schema.TextLine(


### PR DESCRIPTION
Fix empty context.REQUEST.get('form.widgets.taxonomy'), add 'form.widgets.taxonomy' into REQUEST POST form.
