### PR TITLE
Plone 5 fixture and cleanup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,9 @@ Changes
 - Use context language to find index.
   [bsuttor]
 
+- Use lxml instead of elementtree
+  [tomgross]
+
 
 1.3.0 (2016-07-07)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -44,13 +44,13 @@ setup(
         'plone.api',
         'plone.app.registry',
         'plone.app.dexterity',
-        'elementtree',
     ],
     extras_require={
         'test': [
             'plone.testing',
             'plone.app.testing',
             'plone.app.contenttypes',
+            'plone.app.robotframework[debug]',
         ]
     },
     entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'plone.api',
         'plone.app.registry',
         'plone.app.dexterity',
+        'lxml',
     ],
     extras_require={
         'test': [

--- a/src/collective/taxonomy/behavior.py
+++ b/src/collective/taxonomy/behavior.py
@@ -91,7 +91,7 @@ class TaxonomyBehavior(Persistent):
         add('group', Record(field.TextLine(), unicode('Taxonomy')))
         add('operations', Record(field.List(value_type=field.TextLine()),
             [u'plone.app.querystring.operation.selection.is']))
-        add('vocabulary', Record(field.TextLine(), unicode(self.name)))
+        add('vocabulary', Record(field.TextLine(), unicode(self.vocabulary_name)))
         add('sortable', Record(field.Bool(), False))
         add('description', Record(field.Text(), unicode('')))
 
@@ -99,7 +99,7 @@ class TaxonomyBehavior(Persistent):
         context = getSite()
         sm = context.getSiteManager()
         sm.registerAdapter(
-            TaxonomyIndexer(self.field_name, self.name),
+            TaxonomyIndexer(self.field_name, self.vocabulary_name),
             (IDexterityContent, IZCatalog),
             IIndexer, name=self.field_name)
 

--- a/src/collective/taxonomy/browser.py
+++ b/src/collective/taxonomy/browser.py
@@ -4,7 +4,7 @@ from zope.component import getSiteManager
 from zope.publisher.interfaces import NotFound
 from zope.traversing.interfaces import ITraversable
 from zope.schema.interfaces import IVocabularyFactory
-from zope.interface import implements
+from zope.interface import implementer_only
 
 
 class TaxonomyView(BrowserView):
@@ -39,21 +39,15 @@ class TaxonomyView(BrowserView):
 class VocabularyTuplesView(BrowserView):
 
     def __init__(self, context, request, vocabulary):
-        self.context = context
-        self.request = request
+        super(VocabularyTuplesView, self).__init__(self.context, self.request)
         self.vocabulary = vocabulary
 
     def __call__(self):
         return ((term.token, term.title) for term in self.vocabulary)
 
 
-class TaxonomyTraverser(object):
-
-    implements(ITraversable)
-
-    def __init__(self, context, request):
-        self.context = context
-        self.request = request
+@implementer_only(ITraversable)
+class TaxonomyTraverser(BrowserView):
 
     def traverse(self, name, remaining):
         sm = getSiteManager()

--- a/src/collective/taxonomy/controlpanel.py
+++ b/src/collective/taxonomy/controlpanel.py
@@ -19,7 +19,6 @@ from collective.taxonomy.factory import registerTaxonomy
 from collective.taxonomy.interfaces import ITaxonomy
 from collective.taxonomy.interfaces import ITaxonomySettings
 from collective.taxonomy.interfaces import ITaxonomyForm
-from collective.taxonomy.interfaces import get_lang_code
 from collective.taxonomy.exportimport import TaxonomyImportExportAdapter
 
 
@@ -47,13 +46,13 @@ class TaxonomySettingsControlPanel(controlpanel.RegistryEditForm):
         self.actions['export'].addClass("context")
 
     @button.buttonAndHandler(_(u'label_add_taxonomy', default='Add'),
-                    name='add-taxonomy')
+                             name='add-taxonomy')
     def handle_add_taxonomy_action(self, action):
         self.request.RESPONSE.redirect(
             self.context.portal_url() + '/@@taxonomy-add')
 
     @button.buttonAndHandler(_(u'label_edit_taxonomy', default='Edit'),
-                    name='edit-taxonomy')
+                             name='edit-taxonomy')
     def handle_edit_taxonomy_action(self, action):
         data, errors = self.extractData()
         if len(data.get('taxonomies', [])) > 0:
@@ -78,7 +77,6 @@ class TaxonomySettingsControlPanel(controlpanel.RegistryEditForm):
         else:
             api.portal.show_message(_(u"Please select one taxonomy."),
                                     request=self.request)
-
 
     @button.buttonAndHandler(_(u'label_delete_taxonomy', default='Delete taxonomy'),
                              name='delete-taxonomy')

--- a/src/collective/taxonomy/controlpanel.py
+++ b/src/collective/taxonomy/controlpanel.py
@@ -16,7 +16,10 @@ from z3c.form.interfaces import HIDDEN_MODE
 
 from collective.taxonomy.i18n import CollectiveTaxonomyMessageFactory as _
 from collective.taxonomy.factory import registerTaxonomy
-from collective.taxonomy.interfaces import ITaxonomy, ITaxonomySettings, ITaxonomyForm
+from collective.taxonomy.interfaces import ITaxonomy
+from collective.taxonomy.interfaces import ITaxonomySettings
+from collective.taxonomy.interfaces import ITaxonomyForm
+from collective.taxonomy.interfaces import get_lang_code
 from collective.taxonomy.exportimport import TaxonomyImportExportAdapter
 
 
@@ -220,22 +223,18 @@ class TaxonomyEditFormAdapter(object):
     implements(ITaxonomyForm)
 
     def __init__(self, context):
-        if context.REQUEST.get('form.widgets.taxonomy') is None:
+        taxonomy = context.REQUEST.get('form.widgets.taxonomy')
+        if taxonomy is None:
             return
 
-        taxonomy = context.REQUEST.get('form.widgets.taxonomy')
-
         sm = context.getSiteManager()
-        utility = sm.queryUtility(ITaxonomy,
-                                  name=taxonomy)
-
+        utility = sm.getUtility(ITaxonomy, name=taxonomy)
         generated_name = utility.getGeneratedName()
 
         self.__dict__['context'] = context
         self.__dict__['utility'] = utility
         self.__dict__['taxonomy'] = context.REQUEST.get('taxonomy')
-        self.__dict__['behavior'] = sm.queryUtility(IBehavior,
-                                                    name=generated_name)
+        self.__dict__['behavior'] = sm.queryUtility(IBehavior, name=generated_name)
 
     def __getattr__(self, attr):
         if 'behavior' not in self.__dict__:

--- a/src/collective/taxonomy/exportimport.py
+++ b/src/collective/taxonomy/exportimport.py
@@ -3,7 +3,7 @@ import ConfigParser
 from plone.behavior.interfaces import IBehavior
 
 from io import BytesIO
-from elementtree import ElementTree
+from lxml.etree import fromstring
 
 from .interfaces import ITaxonomy
 from .factory import registerTaxonomy
@@ -131,7 +131,7 @@ class TaxonomyImportExportAdapter(object):
     def importDocument(self, taxonomy, document):
         # XXX: we should change this
 
-        tree = ElementTree.fromstring(document)
+        tree = fromstring(document)
         # taxonomy.clean()
 
         results = ImportVdex(tree, self.IMSVDEX_NS)()

--- a/src/collective/taxonomy/exportimport.py
+++ b/src/collective/taxonomy/exportimport.py
@@ -5,9 +5,9 @@ from plone.behavior.interfaces import IBehavior
 from io import BytesIO
 from lxml.etree import fromstring
 
-from .interfaces import ITaxonomy
-from .factory import registerTaxonomy
-from .vdex import ImportVdex, ExportVdex
+from collective.taxonomy.interfaces import ITaxonomy
+from collective.taxonomy.factory import registerTaxonomy
+from collective.taxonomy.vdex import ImportVdex, ExportVdex
 
 
 def parseConfigFile(data):
@@ -76,10 +76,9 @@ def importTaxonomy(context):
 
 def exportTaxonomy(context):
     site = context.getSite()
-    for (name, taxonomy) in site.getSiteManager().getUtilitiesFor(ITaxonomy):
-        behavior = site.getSiteManager().queryUtility(
-            IBehavior, name=taxonomy.getGeneratedName()
-        )
+    sm = site.getSiteManager()
+    for (name, taxonomy) in sm.getUtilitiesFor(ITaxonomy):
+        behavior = sm.queryUtility(IBehavior, name=taxonomy.getGeneratedName())
 
         short_name = name.split('.')[-1]
         exporter = TaxonomyImportExportAdapter(context)

--- a/src/collective/taxonomy/generated.py
+++ b/src/collective/taxonomy/generated.py
@@ -62,5 +62,6 @@ class Wrapper(object):
 
         return getattr(self.__dict__['wrapped'], name)
 
+
 if type(sys.modules[__name__]) is not Wrapper:
     sys.modules[__name__] = Wrapper(sys.modules[__name__])

--- a/src/collective/taxonomy/i18n.py
+++ b/src/collective/taxonomy/i18n.py
@@ -2,4 +2,3 @@ from zope.i18nmessageid import MessageFactory
 
 _pmf = MessageFactory('plone')
 CollectiveTaxonomyMessageFactory = MessageFactory('collective.taxonomy')
-

--- a/src/collective/taxonomy/indexer.py
+++ b/src/collective/taxonomy/indexer.py
@@ -7,12 +7,14 @@ from plone.dexterity.interfaces import IDexterityContent
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.ZCatalog.interfaces import IZCatalog
 from zope.component import adapts
-from zope.interface import classImplements
+from zope.interface import implementer
 
-from .interfaces import ITaxonomy
+from collective.taxonomy.interfaces import ITaxonomy
 
 import collections
 import logging
+
+
 logger = logging.getLogger("collective.taxonomy")
 
 
@@ -69,10 +71,10 @@ class TaxonomyIndexerWrapper(object):
         return result
 
 
+@implementer(IIndexer)
 class TaxonomyIndexer(object):
     __name__ = 'TaxonomyIndexer'
 
-    classImplements(IIndexer)
     adapts(IDexterityContent, IZCatalog)
 
     def __init__(self, field_name, utility_name):
@@ -82,6 +84,7 @@ class TaxonomyIndexer(object):
     def __call__(self, context, catalog):
         return TaxonomyIndexerWrapper(self.field_name, self.utility_name,
                                       context, catalog)
+
 
 def get_language(obj):
     lang = getattr(obj, 'language', None)

--- a/src/collective/taxonomy/interfaces.py
+++ b/src/collective/taxonomy/interfaces.py
@@ -58,6 +58,12 @@ def taxonomyDefaultValue():
     return taxonomy
 
 
+def get_lang_code(lang=None):
+    if lang is None:
+        lang = api.portal.get_current_language()
+    return lang.split('-', 1)[0]
+
+
 class ITaxonomyForm(Interface):
 
     taxonomy = schema.TextLine(
@@ -82,7 +88,8 @@ class ITaxonomyForm(Interface):
     default_language = schema.Choice(
         title=_(u"Default language"),
         vocabulary='collective.taxonomy.languages',
-        required=True
+        required=True,
+        defaultFactory=get_lang_code
     )
 
     import_file = NamedBlobFile(

--- a/src/collective/taxonomy/jsonimpl.py
+++ b/src/collective/taxonomy/jsonimpl.py
@@ -10,6 +10,7 @@ from zope.i18n import translate
 
 from collective.taxonomy import PATH_SEPARATOR
 from collective.taxonomy.i18n import CollectiveTaxonomyMessageFactory as _
+from collective.taxonomy.interfaces import get_lang_code
 from collective.taxonomy.interfaces import ITaxonomy
 from collective.taxonomy.vdex import TreeExport
 
@@ -73,8 +74,11 @@ class EditTaxonomyData(TreeExport, BrowserView):
         mapping = portal_state.locale().displayNames.languages
         language_tool = api.portal.get_tool('portal_languages')
         supported_langs = language_tool.supported_langs
-        languages_mapping = dict(
-            [(lang, mapping[lang].capitalize()) for lang in supported_langs])
+        languages_mapping = {
+            get_lang_code(lang): mapping[get_lang_code(lang)].capitalize()
+            for lang in supported_langs
+            }
+
 
         # add taxonomy's default language if it is not in supported langs
         default_lang = self.taxonomy.default_language

--- a/src/collective/taxonomy/jsonimpl.py
+++ b/src/collective/taxonomy/jsonimpl.py
@@ -77,9 +77,7 @@ class EditTaxonomyData(TreeExport, BrowserView):
         languages_mapping = {
             get_lang_code(lang): mapping[get_lang_code(lang)].capitalize()
             for lang in supported_langs
-            }
-
-
+        }
         # add taxonomy's default language if it is not in supported langs
         default_lang = self.taxonomy.default_language
         languages_mapping[default_lang] = mapping[default_lang].capitalize()

--- a/src/collective/taxonomy/jsonimpl.py
+++ b/src/collective/taxonomy/jsonimpl.py
@@ -1,4 +1,4 @@
-from elementtree import ElementTree
+from lxml import etree
 import os
 import json
 
@@ -46,7 +46,7 @@ class EditTaxonomyData(TreeExport, BrowserView):
 
     def get_data(self):
         """Get json data."""
-        root = ElementTree.Element('vdex')
+        root = etree.Element('vdex')
         try:
             root = self.buildTree(root)
         except ValueError:

--- a/src/collective/taxonomy/testing.py
+++ b/src/collective/taxonomy/testing.py
@@ -43,4 +43,3 @@ ROBOT_TESTING = FunctionalTesting(
            z2.ZSERVER_FIXTURE),
     name="CollectiveTaxonomy:Acceptance"
 )
-

--- a/src/collective/taxonomy/testing.py
+++ b/src/collective/taxonomy/testing.py
@@ -41,6 +41,6 @@ ROBOT_TESTING = FunctionalTesting(
     bases=(FIXTURE,
            REMOTE_LIBRARY_BUNDLE_FIXTURE,
            z2.ZSERVER_FIXTURE),
-    name="CollectiveSolr:Acceptance"
+    name="CollectiveTaxonomy:Acceptance"
 )
 

--- a/src/collective/taxonomy/testing.py
+++ b/src/collective/taxonomy/testing.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from plone.app.robotframework.testing import REMOTE_LIBRARY_BUNDLE_FIXTURE
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
@@ -35,4 +36,11 @@ INTEGRATION_TESTING = IntegrationTesting(
 
 FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(FIXTURE,), name="TaxonomyFixture:Functional")
+
+ROBOT_TESTING = FunctionalTesting(
+    bases=(FIXTURE,
+           REMOTE_LIBRARY_BUNDLE_FIXTURE,
+           z2.ZSERVER_FIXTURE),
+    name="CollectiveSolr:Acceptance"
+)
 

--- a/src/collective/taxonomy/tests/robot/test_taxonomy.robot
+++ b/src/collective/taxonomy/tests/robot/test_taxonomy.robot
@@ -48,12 +48,12 @@ Scenario: As a manager I can add a taxonomy
 
 TestSetup
   Open test browser
-  a logged in Manager
+#  a logged in Manager
 
 
 TestTeardown
-  a logged in Manager
-  Run keywords  Close all browsers
+#  a logged in Manager
+  Close all browsers
 
 
 # Given

--- a/src/collective/taxonomy/tests/robot/test_taxonomy.robot
+++ b/src/collective/taxonomy/tests/robot/test_taxonomy.robot
@@ -1,0 +1,101 @@
+# ============================================================================
+# EXAMPLE ROBOT TESTS
+# ============================================================================
+#
+# Run this robot test stand-alone:
+#
+#  $ bin/test -s collective.taxonomy -t test_taxonomy.robot --all
+#
+# Run this robot test with robot server (which is faster):
+#
+# 1) Start robot server:
+#
+# $ bin/robot-server --reload-path src collective.solr.testing.COLLECTIVE_SOLR_ROBOT_TESTING
+#
+# 2) Run robot tests:
+#
+# $ bin/robot src/collective/solr/tests/robot/test_search.robot
+#
+# See the http://docs.plone.org for further details (search for robot
+# framework).
+#
+# ============================================================================
+
+*** Settings *****************************************************************
+
+Resource  plone/app/robotframework/selenium.robot
+Resource  plone/app/robotframework/keywords.robot
+Resource  Products/CMFPlone/tests/robot/keywords.robot
+
+Library  Remote  ${PLONE_URL}/RobotRemote
+Library  DateTime
+
+Test Setup  TestSetup
+Test Teardown  TestTeardown
+
+
+*** Test Cases ***************************************************************
+
+Scenario: As a manager I can add a taxonomy
+  Given loged in manager
+   When I search for 'Colorless Green Ideas'
+   Then the search returns '1' results
+    and the search results should include 'Colorless Green Ideas'
+
+*** Keywords *****************************************************************
+
+# Test Setup/Teardown
+
+TestSetup
+  Open test browser
+  a logged in Manager
+
+
+TestTeardown
+  a logged in Manager
+  Run keywords  Close all browsers
+
+
+# Given
+
+a loged in manager
+  Enable autologin as  Manager
+
+
+# When
+
+I search for '${searchterm}'
+  Go to  ${PLONE_URL}/@@search
+  Input text  xpath=//main//input[@name='SearchableText']  ${searchterm}
+
+I filter the search by portal type '${portal_type}'
+  Click Element  xpath=//button[@id='search-filter-toggle']
+  Wait until page contains element  xpath=//input[@id='query-portaltype-Collection']
+  Unselect Checkbox  xpath=//input[@id='query-portaltype-Collection']
+  Unselect Checkbox  xpath=//input[@id='query-portaltype-Document']
+
+I filter the search by creation date '${date_filter}'
+  Click Element  xpath=//button[@id='search-filter-toggle']
+  Wait until page contains element  xpath=//input[@id='query-portaltype-Collection']
+  Select Radio Button  created  query-date-${date_filter}
+
+# Then
+
+the search returns '${result_count}' results
+  Wait until keyword succeeds  5s  1s  XPath Should Match X Times  //strong[@id='search-results-number' and contains(.,'${result_count}')]  1  The search should have returned '${result_count}' results.
+
+the search results should include '${term}'
+  Wait until page contains element  xpath=//ol[@class='searchResults']
+  Page should contain  ${term}
+  XPath Should Match X Times  //div[@id='search-results']//ol//li//a[contains(., '${term}')]  1  Search results should have contained '${term}'.
+
+the search results should not include '${term}'
+  Wait until page contains  Search results
+  Page should not contain element  xpath=//*[@class='searchResults']/a[contains(text(), '${term}')]
+
+
+# Misc
+
+Capture screenshot
+  [Arguments]  ${filename}
+  Capture Page Screenshot  filename=../../../../docs/_screenshots/${filename}

--- a/src/collective/taxonomy/tests/test_controlpanel.py
+++ b/src/collective/taxonomy/tests/test_controlpanel.py
@@ -1,16 +1,9 @@
 # -*- coding: utf-8 -*-
 from collective.taxonomy.testing import FUNCTIONAL_TESTING
-from collective.taxonomy.interfaces import ITaxonomy
 from plone import api
 from plone.app.testing import applyProfile
 from plone.app.testing.interfaces import SITE_OWNER_NAME
 from plone.app.testing.interfaces import SITE_OWNER_PASSWORD
-from plone.schemaeditor.utils import FieldAddedEvent
-from plone.schemaeditor.utils import IEditableSchema
-from zope import schema
-from zope.component import queryUtility
-from zope.event import notify
-from zope.lifecycleevent import ObjectAddedEvent
 import unittest
 from transaction import commit
 from plone.testing.z2 import Browser
@@ -31,7 +24,6 @@ class TestControlPanel(unittest.TestCase):
         self.browser = Browser(self.layer['app'])
         self.browser.addHeader(
             'Authorization', 'Basic {0}:{1}'.format(SITE_OWNER_NAME, SITE_OWNER_PASSWORD))
-
         commit()
 
     def test_add_vocabulary(self):
@@ -43,7 +35,7 @@ class TestControlPanel(unittest.TestCase):
         self.browser.getControl(name='form.widgets.default_language:list').value = ['en']
         self.browser.getForm(id='form').submit('Add')
         self.assertIn('<span class="label">Foo Bar Vocabulary</span>', self.browser.contents)
-        
+     
     def test_edit_vocabulary(self):
         self.browser.open(self.portal.absolute_url() + '/@@taxonomy-settings')
         self.assertIn('id="TaxonomySettings"', self.browser.contents)

--- a/src/collective/taxonomy/tests/test_indexer.py
+++ b/src/collective/taxonomy/tests/test_indexer.py
@@ -2,7 +2,9 @@
 from collective.taxonomy.testing import INTEGRATION_TESTING
 from collective.taxonomy.interfaces import ITaxonomy
 from plone import api
+from plone.app.querystring.interfaces import IQuerystringRegistryReader
 from plone.app.testing import applyProfile
+from plone.registry.interfaces import IRegistry
 from plone.schemaeditor.utils import FieldAddedEvent
 from plone.schemaeditor.utils import IEditableSchema
 from zope import schema
@@ -53,7 +55,6 @@ class TestIndexer(unittest.TestCase):
         query = {}
         query['taxonomy_test'] = '1'
         self.assertEqual(len(portal_catalog(query)), 0)
-
         simple_tax = [val for val in taxonomy['en'].values()]
         taxo_val = simple_tax[0]
         self.document.taxonomy_test = [taxo_val]
@@ -94,3 +95,14 @@ class TestIndexer(unittest.TestCase):
         self.document.taxonomy_test = [taxo_val]
         self.document.reindexObject()
         self.assertEqual(len(portal_catalog(query)), 1)
+
+    def test_querystring_widget(self):
+        registry = queryUtility(IRegistry)
+        config = IQuerystringRegistryReader(registry)()
+        self.assertEqual(
+            config['indexes']['taxonomy_test']['values'].items(),
+            [('1', {'title': u'Information Science'}),
+             ('2', {'title': u'Information Science \xbb Book Collecting'}),
+             ('3', {'title': u'Information Science \xbb Chronology'}),
+             ('5', {'title': u'Information Science \xbb Sport'})]
+        )

--- a/src/collective/taxonomy/tests/test_indexer.py
+++ b/src/collective/taxonomy/tests/test_indexer.py
@@ -100,7 +100,7 @@ class TestIndexer(unittest.TestCase):
         registry = queryUtility(IRegistry)
         config = IQuerystringRegistryReader(registry)()
         self.assertEqual(
-            config['indexes']['taxonomy_test']['values'].items(),
+            sorted(config['indexes']['taxonomy_test']['values'].items()),
             [('1', {'title': u'Information Science'}),
              ('2', {'title': u'Information Science \xbb Book Collecting'}),
              ('3', {'title': u'Information Science \xbb Chronology'}),

--- a/src/collective/taxonomy/tests/test_robot.py
+++ b/src/collective/taxonomy/tests/test_robot.py
@@ -1,0 +1,27 @@
+from collective.taxonomy.testing import ROBOT_TESTING
+from plone.app.testing import ROBOT_TEST_LEVEL
+from plone.testing import layered
+import os
+import unittest
+import robotsuite
+
+
+def test_suite():
+    suite = unittest.TestSuite()
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    robot_dir = os.path.join(current_dir, 'robot')
+    robot_tests = [
+        os.path.join('robot', doc) for doc in
+        os.listdir(robot_dir) if doc.endswith('.robot') and
+        doc.startswith('test_')
+    ]
+    for robot_test in robot_tests:
+        robottestsuite = robotsuite.RobotTestSuite(robot_test)
+        robottestsuite.level = ROBOT_TEST_LEVEL
+        suite.addTests([
+            layered(
+                robottestsuite,
+                layer=ROBOT_TESTING
+            ),
+        ])
+    return suite

--- a/src/collective/taxonomy/upgradesteps.py
+++ b/src/collective/taxonomy/upgradesteps.py
@@ -19,5 +19,8 @@ def reactivateSearchable(tool):
 
 def import_registry(tool):
     tool.runImportStepFromProfile(
-        'profile-collective.taxonomy:default', 'plone.app.registry',
-         run_dependencies=False, purge_old=False)
+        'profile-collective.taxonomy:default',
+        'plone.app.registry',
+        run_dependencies=False,
+        purge_old=False
+    )

--- a/src/collective/taxonomy/utility.py
+++ b/src/collective/taxonomy/utility.py
@@ -96,7 +96,7 @@ class Taxonomy(SimpleItem):
         sm = context.getSiteManager()
         new_args = copy(kwargs)
 
-        new_args['name'] = self.name
+        new_args['name'] = self.getGeneratedName()
         new_args['title'] = self.title
         new_args['description'] = kwargs.get('field_description', u'')
         new_args['field_description'] = new_args['description']

--- a/src/collective/taxonomy/utility.py
+++ b/src/collective/taxonomy/utility.py
@@ -10,14 +10,12 @@ from OFS.SimpleItem import SimpleItem
 
 from persistent.dict import PersistentDict
 
+from plone import api
 from plone.behavior.interfaces import IBehavior
 from plone.dexterity.fti import DexterityFTIModificationDescription
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.memoize import ram
 
-from zope.component import getMultiAdapter
-from zope.component.hooks import getSite
-from zope.component.interfaces import ComponentLookupError
 from zope.interface import implementer
 from zope.lifecycleevent import modified
 
@@ -40,6 +38,10 @@ class Taxonomy(SimpleItem):
         self.name = name
         self.title = title
         self.default_language = default_language
+
+    @property
+    def sm(self):
+        return api.portal.get().getSiteManager()
 
     def __call__(self, context):
 
@@ -74,15 +76,7 @@ class Taxonomy(SimpleItem):
         return 'collective.taxonomy.' + self.getShortName()
 
     def getCurrentLanguage(self, request):
-        try:
-            portal_state = getMultiAdapter(
-                (self, request), name=u'plone_portal_state'
-            )
-
-            language = portal_state.language().split('-', 1)[0]
-        except ComponentLookupError:
-            language = ''  # Force to return default language.
-
+        language = get_lang_code()
         if language in self.data:
             return language
         elif self.default_language in self.data:
@@ -92,8 +86,6 @@ class Taxonomy(SimpleItem):
             return self.data.keys()[0]
 
     def registerBehavior(self, **kwargs):
-        context = getSite()
-        sm = context.getSiteManager()
         new_args = copy(kwargs)
 
         new_args['name'] = self.getGeneratedName()
@@ -102,8 +94,8 @@ class Taxonomy(SimpleItem):
         new_args['field_description'] = new_args['description']
 
         behavior = TaxonomyBehavior(**new_args)
-        sm.registerUtility(behavior, IBehavior,
-                           name=self.getGeneratedName())
+        self.sm.registerUtility(behavior, IBehavior,
+                                name=self.getGeneratedName())
 
         behavior.addIndex()
         behavior.activateSearchable()
@@ -111,9 +103,7 @@ class Taxonomy(SimpleItem):
     def cleanupFTI(self):
         """Cleanup the FTIs"""
         generated_name = self.getGeneratedName()
-        context = getSite()
-        sm = context.getSiteManager()
-        for (name, fti) in sm.getUtilitiesFor(IDexterityFTI):
+        for (name, fti) in self.sm.getUtilitiesFor(IDexterityFTI):
             if generated_name in fti.behaviors:
                 fti.behaviors = [behavior for behavior in
                                  fti.behaviors
@@ -121,12 +111,10 @@ class Taxonomy(SimpleItem):
             modified(fti, DexterityFTIModificationDescription("behaviors", ''))
 
     def updateBehavior(self, **kwargs):
-        sm = getSite().getSiteManager()
-
         behavior_name = self.getGeneratedName()
         short_name = self.getShortName()
 
-        utility = sm.queryUtility(IBehavior, name=behavior_name)
+        utility = self.sm.queryUtility(IBehavior, name=behavior_name)
         if utility:
             utility.deactivateSearchable()
             utility.activateSearchable()
@@ -134,15 +122,13 @@ class Taxonomy(SimpleItem):
 
         delattr(generated, short_name)
 
-        for (name, fti) in sm.getUtilitiesFor(IDexterityFTI):
+        for (name, fti) in self.sm.getUtilitiesFor(IDexterityFTI):
             if behavior_name in fti.behaviors:
                 modified(fti, DexterityFTIModificationDescription("behaviors", ''))
 
     def unregisterBehavior(self):
-        context = getSite()
-        sm = context.getSiteManager()
         behavior_name = self.getGeneratedName()
-        utility = sm.queryUtility(IBehavior, name=behavior_name)
+        utility = self.sm.queryUtility(IBehavior, name=behavior_name)
 
         if utility is None:
             return
@@ -153,7 +139,7 @@ class Taxonomy(SimpleItem):
         utility.deactivateSearchable()
         utility.unregisterInterface()
 
-        sm.unregisterUtility(utility, IBehavior, name=behavior_name)
+        self.sm.unregisterUtility(utility, IBehavior, name=behavior_name)
 
     def clean(self):
         self.data.clear()

--- a/src/collective/taxonomy/utility.py
+++ b/src/collective/taxonomy/utility.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from .behavior import TaxonomyBehavior
-from .interfaces import ITaxonomy
-from .vocabulary import Vocabulary
+from collective.taxonomy.behavior import TaxonomyBehavior
+from collective.taxonomy.interfaces import ITaxonomy
+from collective.taxonomy.interfaces import get_lang_code
+from collective.taxonomy.vocabulary import Vocabulary
 
 from BTrees.OOBTree import OOBTree
 from OFS.SimpleItem import SimpleItem
@@ -17,7 +18,7 @@ from plone.memoize import ram
 from zope.component import getMultiAdapter
 from zope.component.hooks import getSite
 from zope.component.interfaces import ComponentLookupError
-from zope.interface import implements
+from zope.interface import implementer
 from zope.lifecycleevent import modified
 
 import generated
@@ -31,11 +32,10 @@ from collective.taxonomy import PATH_SEPARATOR
 logger = logging.getLogger("collective.taxonomy")
 
 
+@implementer(ITaxonomy)
 class Taxonomy(SimpleItem):
-    implements(ITaxonomy)
 
     def __init__(self, name, title, default_language):
-        super(Taxonomy, self).__init__(self)
         self.data = PersistentDict()
         self.name = name
         self.title = title

--- a/src/collective/taxonomy/vdex.py
+++ b/src/collective/taxonomy/vdex.py
@@ -1,4 +1,4 @@
-from elementtree import ElementTree
+from lxml import etree
 from plone.supermodel.utils import indent
 
 from collective.taxonomy import PATH_SEPARATOR
@@ -100,16 +100,16 @@ class TreeExport(object):
     def makeSubtree(self, index, table):
         termnodes = []
         for identifier in index.keys():
-            termnode = ElementTree.Element('term')
-            identifiernode = ElementTree.Element('termIdentifier')
+            termnode = etree.Element('term')
+            identifiernode = etree.Element('termIdentifier')
             identifiernode.text = str(identifier)
-            captionnode = ElementTree.Element('caption')
+            captionnode = etree.Element('caption')
 
             translations = table[identifier].items()
             translations.sort(key=lambda (language, langstring): language)
 
             for (language, langstring) in translations:
-                langstringnode = ElementTree.Element('langstring')
+                langstringnode = etree.Element('langstring')
                 langstringnode.text = langstring
                 langstringnode.attrib['language'] = language or self.taxonomy.default_language or ''
                 captionnode.append(langstringnode)
@@ -171,19 +171,19 @@ class ExportVdex(TreeExport):
         attrib = self.IMSVDEX_ATTRIBS
         attrib['language'] = taxonomy.default_language or ''
 
-        root = ElementTree.Element('vdex', attrib=attrib)
+        root = etree.Element('vdex', attrib=attrib)
 
-        vocabName = ElementTree.Element('vocabName')
+        vocabName = etree.Element('vocabName')
         root.append(vocabName)
 
-        langstring = ElementTree.Element(
+        langstring = etree.Element(
             'langstring',
             attrib={'language': taxonomy.default_language or ''}
         )
         langstring.text = taxonomy.title
         vocabName.append(langstring)
 
-        vocabIdentifier = ElementTree.Element('vocabIdentifier')
+        vocabIdentifier = etree.Element('vocabIdentifier')
         vocabIdentifier.text = self.taxonomy.name.replace(
             'collective.taxonomy.', ''
         )
@@ -193,7 +193,7 @@ class ExportVdex(TreeExport):
 
         if as_string:
             indent(root)
-            treestring = ElementTree.tostring(root, self.IMSVDEX_ENCODING)
+            treestring = etree.tostring(root, self.IMSVDEX_ENCODING)
             header = """<?xml version="1.0" encoding="%s"?>""" % \
                      self.IMSVDEX_ENCODING.upper() + '\n'
             treestring = header + treestring

--- a/src/collective/taxonomy/vocabulary.py
+++ b/src/collective/taxonomy/vocabulary.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from collective.taxonomy.i18n import _pmf
 from interfaces import ITaxonomy
 
 from zope.component import queryMultiAdapter
@@ -11,9 +12,6 @@ from zope.security.interfaces import IPermission
 from zope.component.hooks import getSite
 
 from plone import api
-
-
-_pmf = MessageFactory('plone')
 
 
 class TaxonomyVocabulary(object):

--- a/src/collective/taxonomy/vocabulary.py
+++ b/src/collective/taxonomy/vocabulary.py
@@ -25,16 +25,11 @@ class TaxonomyVocabulary(object):
         results = []
         sm = getSite().getSiteManager()
         utilities = sm.getUtilitiesFor(ITaxonomy)
-
-        for (utility_name, utility) in utilities:
-            utility_name = utility.name
-            utility_title = utility.title
-
-            results.append(SimpleTerm(value=utility_name,
-                                      title=utility_title)
-                           )
-
-        return SimpleVocabulary(results)
+        return SimpleVocabulary([
+            SimpleTerm(value=utility.name,
+                       title=utility.title)
+            for utility_name, utility in utilities
+        ])
 
 
 class Vocabulary(object):
@@ -48,8 +43,7 @@ class Vocabulary(object):
         self.message = MessageFactory(name)
 
     def __iter__(self):
-        for term in self.getTerms():
-            yield term
+        return iter(self.getTerms())
 
     def __len__(self):
         return len(self.getTerms())


### PR DESCRIPTION
This PR superseeds #29 with a cleaner commit history. The contents are

-    Fixes #27
-    Starts with current language when creating a taxonomy
-    Fixes failure on creating taxonomy, if site is set to extended language (en_US)
-    Switch from elemttree to lxml

