### PR TITLE
Fix issue of ++traverse++taxonomy_short_name being broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ env:
 cache:
   pip: true
   directories:
-    - eggs
-    - downloads
+    - buildout-cache/eggs       # see buildout-cache.cfg
+    - buildout-cache/downloads  # see buildout-cache.cfg
 install:
   - sed -ie "s#test-5.x.cfg#travis-$PLONE_VERSION.x.cfg#" buildout.cfg
   - python bootstrap.py --buildout-version=2.9.4 --setuptools-version=33.1.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,10 @@ Changes
   the persistent local registry on taxonomy removal
   [datakurre]
 
+- Fix issue where public ++taxonomy++short_name -traverser for returning
+  generator of (key, label) tuples for given taxonomy was broken
+  [datakurre]
+
 
 1.4.4 (2016-11-29)
 ------------------

--- a/src/collective/taxonomy/browser.py
+++ b/src/collective/taxonomy/browser.py
@@ -1,10 +1,11 @@
-from Products.Five.browser import BrowserView
 from collective.taxonomy.interfaces import ITaxonomy
+from Products.Five.browser import BrowserView
 from zope.component import getSiteManager
-from zope.publisher.interfaces import NotFound
-from zope.traversing.interfaces import ITraversable
-from zope.schema.interfaces import IVocabularyFactory
+from zope.i18n import translate
 from zope.interface import implementer_only
+from zope.publisher.interfaces import NotFound
+from zope.schema.interfaces import IVocabularyFactory
+from zope.traversing.interfaces import ITraversable
 
 
 class TaxonomyView(BrowserView):
@@ -39,11 +40,14 @@ class TaxonomyView(BrowserView):
 class VocabularyTuplesView(BrowserView):
 
     def __init__(self, context, request, vocabulary):
-        super(VocabularyTuplesView, self).__init__(self.context, self.request)
+        super(VocabularyTuplesView, self).__init__(context, request)
         self.vocabulary = vocabulary
 
-    def __call__(self):
-        return ((term.token, term.title) for term in self.vocabulary)
+    def __call__(self, target_language=None):
+        return ((term.token, translate(term.title,
+                                       context=self.request,
+                                       target_language=target_language))
+                for term in self.vocabulary)
 
 
 @implementer_only(ITraversable)

--- a/src/collective/taxonomy/tests/test_traverser.py
+++ b/src/collective/taxonomy/tests/test_traverser.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from collective.taxonomy.testing import INTEGRATION_TESTING
+from collective.taxonomy.browser import VocabularyTuplesView
+from collective.taxonomy.vocabulary import Vocabulary
+
+import unittest
+
+
+class TestTaxonomyTraverser(unittest.TestCase):
+    """Test taxonomy traverser"""
+
+    layer = INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+    def test_traverser(self):
+        view = self.portal.restrictedTraverse('++taxonomy++test')
+
+        self.assertIsInstance(view, VocabularyTuplesView)
+        self.assertIsInstance(view.vocabulary, Vocabulary)
+
+        keys, labels = zip(*view())
+
+        self.assertIn(u'Information Science', labels)
+
+        keys, labels = zip(*view(target_language='de'))
+
+        self.assertIn(u'Informatik', labels)
+        self.assertNotIn(u'Information Science', labels)


### PR DESCRIPTION
We use this to easily access localized vocabularies from restricted TTW code (is also compatible as PloneFormGen vocabulary)

Also added test for this.