### PR TITLE
fix GS export/import in python3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes
 2.0.0 (unreleased)
 ------------------
 
+- Fix GenericSetup import/export in python3
+  [erral]
+
 - Use taxonomy default language for indexing if current language is not available
   [agitator]
 

--- a/src/collective/taxonomy/exportimport.py
+++ b/src/collective/taxonomy/exportimport.py
@@ -92,26 +92,20 @@ def exportTaxonomy(context):
             for name in ['title', 'description', 'default_language']:
                 value = getattr(taxonomy, name, None)
                 if value:
-                    if isinstance(value, six.string_types):
-                        config.set('taxonomy', name, value.encode('utf-8'))
-                    else:
-                        config.set('taxonomy', name, value)
+                    config.set('taxonomy', name, six.ensure_text(value))
 
             for name in ['field_title', 'field_description',
                          'write_permission', 'taxonomy_fieldset']:
                 value = getattr(behavior, name, None)
                 if value:
-                    if isinstance(value, six.string_types):
-                        config.set('taxonomy', name, value.encode('utf-8'))
-                    else:
-                        config.set('taxonomy', name, value)
+                    config.set('taxonomy', name, six.ensure_text(value))
 
             for name in ['is_single_select', 'is_required']:
                 value = getattr(behavior, name, None)
                 if value:
                     config.set('taxonomy', name, str(value).lower())
 
-            filehandle = BytesIO()
+            filehandle = StringIO()
             config.write(filehandle)
             context.writeDataFile('taxonomies/' + short_name + '.cfg',
                                   filehandle.getvalue(), 'text/plain')


### PR DESCRIPTION
I am using collective.taxonomy in Plone 5.2rc3 and python3 and found export errors when exporting the GS profile.

This changes fix those errors, but I don't know how to write a test for those, there are no tests for the GS import/export utility here.