### PR TITLE
check for the field presence in `TaxonomyIndexerWrapper` more consistent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes
 3.0.1 (unreleased)
 ------------------
 
+- check for the field presence in `TaxonomyIndexerWrapper` more consistent.
+  [mamico]
+
 - export/import of field_prefix value.
   [eikichi18]
 

--- a/src/collective/taxonomy/indexer.py
+++ b/src/collective/taxonomy/indexer.py
@@ -1,3 +1,4 @@
+from Acquisition import aq_base
 from Acquisition import aq_parent
 from collections.abc import Iterable
 from collective.taxonomy.interfaces import ITaxonomy
@@ -24,10 +25,8 @@ class TaxonomyIndexerWrapper(object):
         self.utility_name = utility_name
 
     def __call__(self):
-        # Dirty hack to ensure that it is not an item in a
-        # folder
-
-        if self.field_name not in self.context.__dict__:
+        # field needs to be defined in the context, not by acquisition or containment
+        if not hasattr(aq_base(self.context), self.field_name):
             return []
 
         sm = self.context.portal_url.getSiteManager()

--- a/src/collective/taxonomy/tests/test_indexer.py
+++ b/src/collective/taxonomy/tests/test_indexer.py
@@ -28,7 +28,9 @@ class TestIndexer(unittest.TestCase):
         self.portal = self.layer["portal"]
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
         self.portal.invokeFactory("Document", "doc1", title="Doc", language="en")
+        self.portal.invokeFactory("Folder", "fold1", title="Fold", language="en")
         self.document = self.portal.doc1
+        self.folder = self.portal.fold1
 
         # add computed taxonomy field to Document schema
         self.taxonomy_test = schema.Set(
@@ -116,3 +118,23 @@ class TestIndexer(unittest.TestCase):
         self.document.reindexObject()
         self.assertEqual(len(portal_catalog({"taxonomy_test": "5"})), 0)
         self.assertEqual(len(portal_catalog({"taxonomy_test": "55"})), 1)
+
+    def test_indexer_with_property(self):
+        portal_catalog = api.portal.get_tool("portal_catalog")
+        utility = queryUtility(ITaxonomy, name="collective.taxonomy.test")
+        taxonomy = utility.data
+        index = portal_catalog.Indexes["taxonomy_test"]
+        self.assertEqual(index.numObjects(), 0)
+
+        # overrides field with a property method.
+        # XXX: this is a trick: generally the property will be defined in the
+        # class, but here we do it in the test.
+        taxo_val = taxonomy["en"]["\u241fInformation Science\u241fBook Collecting"]
+        self.folder.__class__.taxonomy_test = property(lambda self: taxo_val)
+
+        self.folder.reindexObject()
+        query = {}
+        query["taxonomy_test"] = "2"
+        self.assertEqual(len(portal_catalog(query)), 1)
+        index = portal_catalog.Indexes["taxonomy_test"]
+        self.assertEqual(index.numObjects(), 1)


### PR DESCRIPTION
with current implementaion: 

https://github.com/collective/collective.taxonomy/compare/mamico_indexwrapper_01?expand=1#diff-8e799d4bd64d5fc2987102444d8302ed42d3bb6fbe570466e5a28926359be2a2L26

I had a problem when, for compatibility reasons, I implemented a property to manage a field in the taxonomy.

Here I propose a different control for the presence of the field that might be more efficient than the current one and that solves my problem.