### PR TITLE
Use setup-plone branch maurits-fixes.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,8 @@ jobs:
           python-version: ${{ matrix.python }}
           plone-version: ${{ matrix.plone }}
           setuptools-version: 66.1.0
+          additional-packages: zest.releaser
+          additional-eggs: zest.pocompile
       - name: Install package
         run: |
           make install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,12 +24,10 @@ jobs:
 
       - name: Setup Plone ${{ matrix.plone }} with Python ${{ matrix.python }}
         id: setup
-        uses: plone/setup-plone@v2.0.0
+        uses: plone/setup-plone@maurits-fixes
         with:
           python-version: ${{ matrix.python }}
           plone-version: ${{ matrix.plone }}
-          setuptools-version: 69.5.1
-          additional-eggs: 'setuptools'
       - name: Install package
         run: |
           make install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           plone-version: ${{ matrix.plone }}
+          setuptools-version: 66.1.0
       - name: Install package
         run: |
           make install


### PR DESCRIPTION
This is for testing https://github.com/plone/setup-plone/pull/4
Not sure if this is the correct spelling.

On that branch we use the setuptools version that is pinned in the constraints of Plone, which should be fine for both 6.0 and 6.1, also on Python 3.12.