### PR TITLE
fix keyword comparison

### DIFF
--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -30,8 +30,6 @@ jobs:
     uses: plone/meta/.github/workflows/test.yml@main
   release_ready:
     uses: plone/meta/.github/workflows/release_ready.yml@main
-  circular:
-    uses: plone/meta/.github/workflows/circular.yml@main
 
 ##
 # To modify the list of default jobs being created add in .meta.toml:

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ parts/
 pyvenv.cfg
 var/
 local.cfg
+.python-version
 
 # mxdev
 /instance/

--- a/.meta.toml
+++ b/.meta.toml
@@ -13,7 +13,6 @@ jobs = [
     "qa",
     "test",
     "release_ready",
-    "circular",
     ]
 
 [gitignore]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes
 3.1.2 (unreleased)
 ------------------
 
+- Fix keywords comparison
+  [mamico]
+
 - Added Italian translation
   [mamico]
 

--- a/src/collective/taxonomy/indexer.py
+++ b/src/collective/taxonomy/indexer.py
@@ -62,7 +62,9 @@ class TaxonomyIndexerWrapper:
         result = []
         for key, value in utility.inverted_data[lang].items():
             for found_identifier, found_language, found_path in found:
-                if found_path.startswith(value) and key not in result:
+                value_split = value.split("\u241f")
+                found_split = found_path.split("\u241f")[: len(value_split)]
+                if found_split == value_split and key not in result:
                     result.append(key)
 
         return result

--- a/src/collective/taxonomy/indexer.py
+++ b/src/collective/taxonomy/indexer.py
@@ -1,6 +1,7 @@
 from Acquisition import aq_base
 from Acquisition import aq_parent
 from collections.abc import Iterable
+from collective.taxonomy import PATH_SEPARATOR
 from collective.taxonomy.interfaces import ITaxonomy
 from plone import api
 from plone.base.interfaces import IPloneSiteRoot
@@ -62,8 +63,8 @@ class TaxonomyIndexerWrapper:
         result = []
         for key, value in utility.inverted_data[lang].items():
             for found_identifier, found_language, found_path in found:
-                value_split = value.split("\u241f")
-                found_split = found_path.split("\u241f")[: len(value_split)]
+                value_split = value.split(PATH_SEPARATOR)
+                found_split = found_path.split(PATH_SEPARATOR)[: len(value_split)]
                 if found_split == value_split and key not in result:
                     result.append(key)
 

--- a/src/collective/taxonomy/profiles/examples/taxonomies/nihms.xml
+++ b/src/collective/taxonomy/profiles/examples/taxonomies/nihms.xml
@@ -50,5 +50,11 @@
         <langstring language="en">Cars</langstring>
       </caption>
     </term>
+    <term>
+      <termIdentifier>56</termIdentifier>
+      <caption>
+        <langstring language="en">Carson</langstring>
+      </caption>
+    </term>
   </term>
-</vdex>
+ </vdex>

--- a/src/collective/taxonomy/profiles/examples/taxonomies/nihms.xml
+++ b/src/collective/taxonomy/profiles/examples/taxonomies/nihms.xml
@@ -57,4 +57,4 @@
       </caption>
     </term>
   </term>
- </vdex>
+</vdex>

--- a/src/collective/taxonomy/tests/test_controlpanel_restapi.py
+++ b/src/collective/taxonomy/tests/test_controlpanel_restapi.py
@@ -53,4 +53,4 @@ class TestControlPanelRestapi(unittest.TestCase):
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0]["name"], "collective.taxonomy.test")
         self.assertEqual(res[0]["title"], "Test vocabulary")
-        self.assertEqual(res[0]["count"], {"da": 4, "de": 1, "en": 5, "ru": 1})
+        self.assertEqual(res[0]["count"], {"da": 4, "de": 1, "en": 6, "ru": 1})

--- a/src/collective/taxonomy/tests/test_indexer.py
+++ b/src/collective/taxonomy/tests/test_indexer.py
@@ -127,6 +127,7 @@ class TestIndexer(unittest.TestCase):
                 ("3", {"title": "Information Science \xbb Chronology"}),
                 ("5", {"title": "Information Science \xbb Sport"}),
                 ("55", {"title": "Information Science \xbb Cars"}),
+                ("56", {"title": "Information Science \xbb Carson"}),
             ],
         )
 
@@ -145,11 +146,12 @@ class TestIndexer(unittest.TestCase):
         document_schema = fti.lookupSchema()
         notify(ObjectAddedEvent(taxonomy_test, document_schema))
         notify(FieldAddedEvent(fti, taxonomy_test))
-        taxo_val = taxonomy["en"]["\u241fInformation Science\u241fCars"]
+        taxo_val = taxonomy["en"]["\u241fInformation Science\u241fCarson"]
         self.document.taxonomy_test = taxo_val
         self.document.reindexObject()
         self.assertEqual(len(portal_catalog({"taxonomy_test": "5"})), 0)
-        self.assertEqual(len(portal_catalog({"taxonomy_test": "55"})), 1)
+        self.assertEqual(len(portal_catalog({"taxonomy_test": "55"})), 0)  # not Cars ...
+        self.assertEqual(len(portal_catalog({"taxonomy_test": "56"})), 1)  # ... but Carson
 
     def test_indexer_with_property(self):
         portal_catalog = api.portal.get_tool("portal_catalog")

--- a/src/collective/taxonomy/tests/test_indexer.py
+++ b/src/collective/taxonomy/tests/test_indexer.py
@@ -150,8 +150,10 @@ class TestIndexer(unittest.TestCase):
         self.document.taxonomy_test = taxo_val
         self.document.reindexObject()
         self.assertEqual(len(portal_catalog({"taxonomy_test": "5"})), 0)
-        self.assertEqual(len(portal_catalog({"taxonomy_test": "55"})), 0)  # not Cars ...
-        self.assertEqual(len(portal_catalog({"taxonomy_test": "56"})), 1)  # ... but Carson
+        # not Cars ...
+        self.assertEqual(len(portal_catalog({"taxonomy_test": "55"})), 0)
+        # ... but Carson
+        self.assertEqual(len(portal_catalog({"taxonomy_test": "56"})), 1)
 
     def test_indexer_with_property(self):
         portal_catalog = api.portal.get_tool("portal_catalog")

--- a/src/collective/taxonomy/tests/test_taxonomy_endpoint.py
+++ b/src/collective/taxonomy/tests/test_taxonomy_endpoint.py
@@ -39,7 +39,7 @@ class TestTaxonomyEndpoint(unittest.TestCase):
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0]["name"], "collective.taxonomy.test")
         self.assertEqual(res[0]["title"], "Test vocabulary")
-        self.assertEqual(res[0]["count"], {"da": 4, "de": 1, "en": 5, "ru": 1})
+        self.assertEqual(res[0]["count"], {"da": 4, "de": 1, "en": 6, "ru": 1})
 
     def test_get_with_parameters_return_taxonomy_details(self):
         response = self.api_session.get("/@taxonomy/collective.taxonomy.test")

--- a/src/collective/taxonomy/tests/test_utility.py
+++ b/src/collective/taxonomy/tests/test_utility.py
@@ -14,4 +14,4 @@ class TestUtility(unittest.TestCase):
 
         tree = taxonomy.makeVocabulary("en").makeTree()
         self.assertIn("Information Science", tree)
-        self.assertEqual(len(tree["Information Science"]), 4)
+        self.assertEqual(len(tree["Information Science"]), 5)


### PR DESCRIPTION
Fix a bug that occurred when two taxonomy keywords at the same level started the same way.