### PR TITLE
Add fake former_dotted_names attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 3.1.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add fake former_dotted_names attribute to do not broke versioning when there are some taxonomies behaviors.
+  [cekk]
 
 
 3.1.4 (2024-10-24)

--- a/src/collective/taxonomy/behavior.py
+++ b/src/collective/taxonomy/behavior.py
@@ -187,6 +187,13 @@ class TaxonomyBehavior(Persistent):
     def marker(self):
         return getattr(generated, self.short_name)
 
+    @property
+    def former_dotted_names(self):
+        """
+        This is needed to not broke versioning
+        """
+        return self.name
+
     def generateInterface(self):
         logger.debug("generating interface for %s" % self.short_name)
 


### PR DESCRIPTION
I had a content history broken with the following traceback (it seems related to a BlobImage field changed between two versions):

Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 181, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 391, in publish_module
  Module ZPublisher.WSGIPublisher, line 285, in publish
  Module ZPublisher.mapply, line 98, in mapply
  Module ZPublisher.WSGIPublisher, line 68, in call_object
  Module zope.browserpage.simpleviewclass, line 44, in __call__
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 58, in __call__
  Module zope.pagetemplate.pagetemplate, line 134, in pt_render
  Module Products.PageTemplates.engine, line 365, in __call__
  Module z3c.pt.pagetemplate, line 174, in render
  Module chameleon.zpt.template, line 331, in render
  Module chameleon.template, line 217, in render
  Module chameleon.utils, line 20, in raise_with_traceback
  Module chameleon.template, line 193, in render
  Module 780410a05053f34ef67569d9c06c72e2, line 2165, in render
  Module 1adf066ef8359a909534e1a4aa4e8557, line 930, in render_master
  Module 1adf066ef8359a909534e1a4aa4e8557, line 1590, in render_content
  Module 780410a05053f34ef67569d9c06c72e2, line 1793, in __fill_main
  Module zope.tales.pythonexpr, line 73, in __call__
   - __traceback_info__: (pr.retrieve(context, version_id))
  Module <string>, line 1, in <module>
  Module Products.CMFEditions.CopyModifyMergeRepositoryTool, line 376, in retrieve
  Module Products.CMFEditions.CopyModifyMergeRepositoryTool, line 512, in _retrieve
  Module Products.CMFEditions.CopyModifyMergeRepositoryTool, line 585, in _recursiveRetrieve
  Module Products.CMFEditions.ArchivistTool, line 353, in retrieve
  Module Products.CMFEditions.ArchivistTool, line 525, in __getitem__
  Module Products.CMFEditions.ModifierRegistryTool, line 163, in reattachReferencedAttributes
  Module plone.app.versioningbehavior.modifiers, line 140, in reattachReferencedAttributes
  Module plone.behavior.registration, line 93, in lookup_behavior_registration
AttributeError: 'TaxonomyBehavior' object has no attribute 'former_dotted_names'


The problem is here: https://github.com/plone/plone.app.versioningbehavior/blob/master/plone/app/versioningbehavior/modifiers.py#L140

Where the method tries to check if there is a behavior with the name of the interface, and plone.behavior needs an attribute "former_dotted_names" for backward compatibility.

TaxononmyBehavior does not provide this attribute and the versioning get broken.
I added a new attribute that returns the behavior dotted name as fallback.