### PR TITLE
Fix querystring operations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 3.1.7 (unreleased)
 ------------------
 
-- Update querystring operations to enable any/all/none queryies for taxonomy indexes.
+- Update querystring operations to enable any/all/none queries for taxonomy indexes.
   [petschki]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 3.1.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Update querystring operations to enable any/all/none queryies for taxonomy indexes.
+  [petschki]
 
 
 3.1.6 (2025-03-18)

--- a/src/collective/taxonomy/behavior.py
+++ b/src/collective/taxonomy/behavior.py
@@ -126,6 +126,7 @@ class TaxonomyBehavior(Persistent):
             Record(
                 field.List(value_type=field.TextLine()),
                 [
+                    "plone.app.querystring.operation.selection.is",
                     "plone.app.querystring.operation.selection.all",
                     "plone.app.querystring.operation.selection.any",
                     "plone.app.querystring.operation.selection.none",

--- a/src/collective/taxonomy/behavior.py
+++ b/src/collective/taxonomy/behavior.py
@@ -125,7 +125,11 @@ class TaxonomyBehavior(Persistent):
             "operations",
             Record(
                 field.List(value_type=field.TextLine()),
-                ["plone.app.querystring.operation.selection.is"],
+                [
+                    "plone.app.querystring.operation.selection.all",
+                    "plone.app.querystring.operation.selection.any",
+                    "plone.app.querystring.operation.selection.none",
+                ],
             ),
         )
         add(

--- a/src/collective/taxonomy/profiles/default/metadata.xml
+++ b/src/collective/taxonomy/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>2000</version>
+  <version>2001</version>
   <dependencies>
 </dependencies>
 </metadata>

--- a/src/collective/taxonomy/upgradesteps.zcml
+++ b/src/collective/taxonomy/upgradesteps.zcml
@@ -47,5 +47,15 @@
         handler=".upgradesteps.update_configlet_icon"
         />
   </genericsetup:upgradeSteps>
-
+  <genericsetup:upgradeSteps
+      profile="collective.taxonomy:default"
+      source="2000"
+      destination="2001"
+      >
+    <genericsetup:upgradeStep
+        title="Update searchable for every taxonomy"
+        description="Fix operations for all/any/none queries."
+        handler=".upgradesteps.reactivateSearchable"
+        />
+  </genericsetup:upgradeSteps>
 </configure>


### PR DESCRIPTION
To enable any/all/none queries for taxonomy indexes (in `pat-querystring` aka Collection editform) 