### PR TITLE
Translate labels correctly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changes
 - Update querystring operations to enable any/all/none queries for taxonomy indexes.
   [petschki]
 
+- fix available term labels cachekey to be translated correctly when switching languages.
+  [petschki]
 
 3.1.6 (2025-03-18)
 ------------------

--- a/src/collective/taxonomy/widget.py
+++ b/src/collective/taxonomy/widget.py
@@ -1,4 +1,5 @@
 from collective.taxonomy.interfaces import ITaxonomySelectWidget
+from plone import api
 from plone.memoize import ram
 from z3c.form import interfaces
 from z3c.form.widget import FieldWidget
@@ -19,7 +20,8 @@ def _items_cachekey(fun, self):
     # try to get modified time of taxonomy utility
     try:
         mtime = self.terms.terms.data._p_mtime
-        key = f"{self.field.__name__}-{mtime}"
+        lng = api.portal.get_current_language()
+        key = f"{self.field.__name__}-{lng}-{mtime}"
         return key
     except AttributeError:
         # XXX: this happens with newly created taxonomies


### PR DESCRIPTION
The list of available terms in the "orderedselectwidget" doesn't get translated correctly when switching languages because its cached on `_p_mtime` of the terms data only. This PR fixes the cachekey to respect current context language too.