### PR TITLE
PEP 420 native namespace

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -20,15 +20,13 @@ jobs:
         config:
         # [Python version, visual name, tox env]
         - ["3.13", "6.2 on py3.13", "py313-plone62"]
-        - ["3.13", "6.1 on py3.13", "py313-plone61"]
-        - ["3.10", "6.1 on py3.10", "py310-plone61"]
-        - ["3.9", "6.0 on py3.9", "py39-plone60"]
+        - ["3.10", "6.2 on py3.10", "py310-plone62"]
 
     runs-on: ${{ matrix.os[1] }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         persist-credentials: false
     - name: Set up Python
@@ -36,8 +34,16 @@ jobs:
       with:
         python-version: ${{ matrix.config[0] }}
         allow-prereleases: true
+
+##
+# Add extra configuration options in .meta.toml:
+#  [github]
+#  extra_lines_after_os_dependencies = """
+#  _your own configuration lines_
+#  """
+##
     - name: Pip cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}
@@ -48,5 +54,19 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox
+    - name: Initialize tox
+      # the bash one-liner below does not work on Windows
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        if [ `tox list --no-desc -f init|wc -l` = 1 ]; then tox -e init;else true; fi
     - name: Test
       run: tox -e ${{ matrix.config[2] }}
+
+
+##
+# Add extra configuration options in .meta.toml:
+#  [github]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##

--- a/.meta.toml
+++ b/.meta.toml
@@ -3,7 +3,7 @@
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "2.0.1.dev0"
+commit-id = "2.3.1"
 
 [pyproject]
 codespell_skip = "*.js,*.min.js,*.min.js.map,*.min.css.map,*.svg,*.lock,*.json"
@@ -22,4 +22,4 @@ test_*
 """
 
 [tox]
-test_matrix = {"6.2" = ["3.13"], "6.1" = ["3.13", "3.10"], "6.0" = ["3.9"]}
+test_matrix = {"6.2" = ["*"]}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,20 +7,20 @@ ci:
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
         args: [--py38-plus]
 -   repo: https://github.com/pycqa/isort
-    rev: 6.0.1
+    rev: 7.0.0
     hooks:
     -   id: isort
--   repo: https://github.com/psf/black
-    rev: 25.1.0
+-   repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 25.11.0
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty
-    rev: 3.1.0
+    rev: 3.1.1
     hooks:
     -   id: zpretty
 
@@ -32,7 +32,7 @@ repos:
 #  """
 ##
 -   repo: https://github.com/PyCQA/flake8
-    rev: 7.1.2
+    rev: 7.3.0
     hooks:
     -   id: flake8
 
@@ -58,20 +58,20 @@ repos:
 #  """
 ##
 -   repo: https://github.com/mgedmin/check-manifest
-    rev: "0.50"
+    rev: "0.51"
     hooks:
     -   id: check-manifest
 -   repo: https://github.com/regebro/pyroma
-    rev: "4.2"
+    rev: "5.0"
     hooks:
     -   id: pyroma
 -   repo: https://github.com/mgedmin/check-python-versions
-    rev: "0.22.1"
+    rev: "0.24.0"
     hooks:
     -   id: check-python-versions
         args: ['--only', 'setup.py,pyproject.toml']
 -   repo: https://github.com/collective/i18ndude
-    rev: "6.2.1"
+    rev: "6.3.0"
     hooks:
     -   id: i18ndude
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changes
 4.0.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+  Support only Plone 6.2 and Python 3.10+.
 
 3.1.7 (2025-04-28)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changes
 =======
 
-3.1.8 (unreleased)
+4.0.0 (unreleased)
 ------------------
 
 - Nothing changed yet.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [build-system]
-requires = ["setuptools>=68.2,<=75.8.0", "wheel"]
+requires = ["setuptools>=68.2,<80", "wheel"]
 
 ##
 # Add extra configuration options in .meta.toml:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = "3.1.8.dev0"
+version = "4.0.0.dev0"
 long_description = (
     f"{Path('README.rst').read_text()}\n{Path('CHANGES.rst').read_text()}"
 )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -19,14 +18,12 @@ setup(
         "Development Status :: 6 - Mature",
         "Environment :: Web Environment",
         "Framework :: Plone",
-        "Framework :: Plone :: 6.0",
-        "Framework :: Plone :: 6.1",
+        "Framework :: Plone :: 6.2",
         "Framework :: Plone :: Addon",
         "Framework :: Zope",
         "Framework :: Zope :: 5",
         "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
@@ -36,14 +33,10 @@ setup(
     author="Bo Simonsen and Malthe Borch",
     author_email="bo@headnet.dk",
     license="GPLv2+",
-    packages=find_packages("src"),
-    package_dir={"": "src"},
-    namespace_packages=["collective"],
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     install_requires=[
-        "setuptools",
         "plone.base",
         "plone.supermodel",
         "plone.api >= 1.5",

--- a/src/collective/__init__.py
+++ b/src/collective/__init__.py
@@ -1,6 +1,0 @@
-try:
-    __import__("pkg_resources").declare_namespace(__name__)
-except ImportError:
-    from pkgutil import extend_path
-
-    __path__ = extend_path(__path__, __name__)

--- a/tox.ini
+++ b/tox.ini
@@ -8,19 +8,20 @@ envlist =
     lint
     test
     py313-plone62
-    py313-plone61
-    py310-plone61
-    py39-plone60
+    py312-plone62
+    py311-plone62
+    py310-plone62
     dependencies
 
 
 ##
 # Add extra configuration options in .meta.toml:
 # - to specify a custom testing combination of Plone and python versions, use `test_matrix`
+#   Use ["*"] to use all supported Python versions for this Plone version.
 # - to specify extra custom environments, use `envlist_lines`
 # - to specify extra `tox` top-level options, use `config_lines`
 #  [tox]
-#  test_matrix = {"6.2" = ["3.13", "3.12"], "6.1" = ["3.10", "3.9"]}
+#  test_matrix = {"6.2" = ["3.13", "3.12"], "6.1" = ["*"]}
 #  envlist_lines = """
 #      my_other_environment
 #  """
@@ -112,8 +113,6 @@ set_env =
 deps =
     {[test_runner]deps}
     plone62: -c https://dist.plone.org/release/6.2-dev/constraints.txt
-    plone61: -c https://dist.plone.org/release/6.1-dev/constraints.txt
-    plone60: -c https://dist.plone.org/release/6.0-dev/constraints.txt
 
 ##
 # Specify additional deps in .meta.toml:
@@ -154,6 +153,7 @@ set_env = {[base]set_env}
 deps =
     {[test_runner]deps}
     -c https://dist.plone.org/release/6.2-dev/constraints.txt
+
 commands = {[test_runner]test}
 extras = {[base]extras}
 
@@ -179,6 +179,7 @@ deps =
     {[test_runner]deps}
     coverage
     -c https://dist.plone.org/release/6.2-dev/constraints.txt
+
 commands = {[test_runner]coverage}
 extras = {[base]extras}
 
@@ -190,7 +191,6 @@ deps =
     twine
     build
     -c https://dist.plone.org/release/6.2-dev/constraints.txt
-
 commands =
     python -m build --sdist
     twine check dist/*
@@ -217,7 +217,6 @@ deps =
     pipdeptree
     pipforester
     -c https://dist.plone.org/release/6.2-dev/constraints.txt
-
 commands =
     # Generate the full dependency tree
     sh -c 'pipdeptree -j > forest.json'


### PR DESCRIPTION
Update it with `plone.meta` and run the native namespace script to ensure it works on upcoming Plone 6.2.

This should fix #188 and probably any other PR created that has 6.2 on its testing matrix.